### PR TITLE
Adding helper class for computing calibration metrics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ chkp/
 ignore/
 */mnist
 */coco_people
+data/
+
+!data/discrete_sine_wave

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ All regression models should inherit from the `DiscreteRegressionNN` class (foun
 - `_forward_impl` (defines a forward pass through the network)
 - `_predict_impl` (defines how to make predictions with the network, including any transformations on the output of the forward pass)
 - `_sample_impl` (defines how to sample from the network's learned posterior predictive distribution for a given input)
+- `_posterior_predictive_impl` (defines how to produce a posterior predictive distribution from network output)
 - `_point_prediction_impl` (defines how to interpret network output as a single point prediction for a regression target)
 - `_addl_test_metrics_dict` (defines any metrics beyond rmse/mae that are computed during model evaluation)
 - `_update_addl_test_metrics_batch` (defines how to update additional metrics beyond rmse/mae for each test batch).

--- a/README.md
+++ b/README.md
@@ -59,3 +59,37 @@ All regression models should inherit from the `DiscreteRegressionNN` class (foun
 - `_update_addl_test_metrics_batch` (defines how to update additional metrics beyond rmse/mae for each test batch).
 
 See existing model classes like `GaussianNN` (found [here](probcal/models/gaussian_nn.py)) for an example of these steps.
+
+## Measuring Calibration
+
+Once a `DiscreteRegressionNN` subclass is trained, its calibration can be measured on a dataset via the `CalibrationEvaluator`. Example usage:
+
+```python
+from probcal.data_modules import COCOPeopleDataModule
+from probcal.enums import DatasetType
+from probcal.evaluation import CalibrationEvaluator
+from probcal.evaluation import CalibrationEvaluatorSettings
+from probcal.models import GaussianNN
+
+
+# You can customize the settings for the MCMD / ECE computation.
+settings = CalibrationEvaluatorSettings(
+    dataset_type=DatasetType.IMAGE,
+    mcmd_input_kernel="polynomial",
+    mcmd_output_kernel="rbf",
+    mcmd_lmbda=0.1,
+    mcmd_num_samples=5,
+    ece_bins=50,
+    ece_weights="frequency",
+    ece_alpha=1,
+)
+evaluator = CalibrationEvaluator(settings)
+
+model = GaussianNN.load_from_checkpoint("path/to/model.ckpt")
+
+# You can use any lightning data module (preferably, the one with the dataset the model was trained on).
+data_module = COCOPeopleDataModule(root_dir="data", batch_size=4, num_workers=0, persistent_workers=False)
+calibration_results = evaluator(model=model, data_module=data_module)
+```
+
+Invoking the `CalibrationEvaluator`'s `__call__` method (as above) kicks off an extensive evaluation wherein MCMD and ECE are computed for the specified model. This passes back a `CalibrationResults` object, which will contain the computed metrics and other helpful variables for further analysis.

--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ All regression models should inherit from the `DiscreteRegressionNN` class (foun
 
 - `_forward_impl` (defines a forward pass through the network)
 - `_predict_impl` (defines how to make predictions with the network, including any transformations on the output of the forward pass)
-- `_point_prediction` (defines how to interpret network output as a single point prediction for a regression target)
+- `_sample_impl` (defines how to sample from the network's learned posterior predictive distribution for a given input)
+- `_point_prediction_impl` (defines how to interpret network output as a single point prediction for a regression target)
 - `_addl_test_metrics_dict` (defines any metrics beyond rmse/mae that are computed during model evaluation)
 - `_update_addl_test_metrics_batch` (defines how to update additional metrics beyond rmse/mae for each test batch).
 

--- a/probcal/evaluation/__init__.py
+++ b/probcal/evaluation/__init__.py
@@ -1,0 +1,2 @@
+from .calibration_evaluator import CalibrationEvaluator
+from .calibration_evaluator import CalibrationEvaluatorSettings

--- a/probcal/evaluation/kernels.py
+++ b/probcal/evaluation/kernels.py
@@ -1,0 +1,76 @@
+"""A compilation of pytorch-native kernels."""
+import torch
+
+
+def rbf_kernel(x: torch.Tensor, x_prime: torch.Tensor, gamma: float | None = None) -> torch.Tensor:
+    """Pytorch implementation of sklearn's RBF kernel.
+
+    Args:
+        x (torch.Tensor): A (n,) or (n,d) feature tensor.
+        x_prime (torch.Tensor): A (m,) or (m,d) feature tensor.
+        gamma (float | None, optional): Gamma parameter for the kernel. If None, defaults to 1.0 / d.
+
+    Raises:
+        ValueError: If x and x_prime do not have the same number of dimensions.
+        ValueError: If x and x_prime do not have the same feature dimension.
+
+    Returns:
+        torch.Tensor: (n,m) Gram tensor.
+    """
+    if x.ndim != x_prime.ndim:
+        raise ValueError("x and x_prime must have same number of dimensions.")
+
+    if x.ndim == 1:
+        x = x.reshape(-1, 1)
+    if x_prime.ndim == 1:
+        x_prime = x_prime.reshape(-1, 1)
+
+    if x.shape[-1] != x_prime.shape[-1]:
+        raise ValueError("x and x_prime must have same feature dimension.")
+
+    gamma = gamma or 1.0 / x.shape[-1]
+    K = torch.exp(-gamma * torch.cdist(x, x_prime, p=2) ** 2)
+    return K
+
+
+def polynomial_kernel(
+    x: torch.Tensor,
+    x_prime: torch.Tensor,
+    gamma: float | None = None,
+    coef0: float = 1.0,
+    degree: int = 3,
+) -> torch.Tensor:
+    """Pytorch implementation of sklearn's polynomial kernel.
+
+    Args:
+        x (torch.Tensor): A (n,) or (n,d) feature tensor.
+        x_prime (torch.Tensor): A (m,) or (m,d) feature tensor.
+        gamma (float | None, optional): Gamma parameter for the kernel. If None, defaults to 1.0 / d.
+        coef0 (float, optional): Coef0 parameter for the kernel (added to the inner product before applying the exponent). Defaults to 1.
+        degree (int, optional): Degree of the polynomial kernel. Defaults to 3.
+
+    Raises:
+        ValueError: If x and x_prime do not have the same number of dimensions.
+        ValueError: If x and x_prime do not have the same feature dimension.
+
+    Returns:
+        torch.Tensor: (n,m) Gram tensor.
+    """
+    if x.ndim != x_prime.ndim:
+        raise ValueError("x and x_prime must have same number of dimensions.")
+
+    if x.ndim == 1:
+        x = x.reshape(-1, 1)
+    if x_prime.ndim == 1:
+        x_prime = x_prime.reshape(-1, 1)
+
+    if x.shape[-1] != x_prime.shape[-1]:
+        raise ValueError("x and x_prime must have same feature dimension.")
+
+    if gamma is None:
+        gamma = 1.0 / x.shape[1]
+    K = torch.matmul(x, x_prime.T)
+    K *= gamma
+    K += coef0
+    K **= degree
+    return K

--- a/probcal/evaluation/kernels.py
+++ b/probcal/evaluation/kernels.py
@@ -33,6 +33,39 @@ def rbf_kernel(x: torch.Tensor, x_prime: torch.Tensor, gamma: float | None = Non
     return K
 
 
+def laplacian_kernel(
+    x: torch.Tensor, x_prime: torch.Tensor, gamma: float | None = None
+) -> torch.Tensor:
+    """Pytorch implementation of sklearn's laplacian kernel.
+
+    Args:
+        x (torch.Tensor): A (n,) or (n,d) feature tensor.
+        x_prime (torch.Tensor): A (m,) or (m,d) feature tensor.
+        gamma (float | None, optional): Gamma parameter for the kernel. If None, defaults to 1.0 / d.
+
+    Raises:
+        ValueError: If x and x_prime do not have the same number of dimensions.
+        ValueError: If x and x_prime do not have the same feature dimension.
+
+    Returns:
+        torch.Tensor: (n,m) Gram tensor.
+    """
+    if x.ndim != x_prime.ndim:
+        raise ValueError("x and x_prime must have same number of dimensions.")
+
+    if x.ndim == 1:
+        x = x.reshape(-1, 1)
+    if x_prime.ndim == 1:
+        x_prime = x_prime.reshape(-1, 1)
+
+    if x.shape[-1] != x_prime.shape[-1]:
+        raise ValueError("x and x_prime must have same feature dimension.")
+
+    gamma = gamma or 1.0 / x.shape[-1]
+    K = torch.exp(-gamma * torch.cdist(x, x_prime, p=1) ** 2)
+    return K
+
+
 def polynomial_kernel(
     x: torch.Tensor,
     x_prime: torch.Tensor,

--- a/probcal/evaluation/metrics.py
+++ b/probcal/evaluation/metrics.py
@@ -15,7 +15,7 @@ def _compute_discrete_torch_dist_cdf(
     y_vals: torch.Tensor,
     max_val: int = 2000,
 ) -> torch.Tensor:
-    support = torch.arange(max_val).unsqueeze(0).repeat(len(y_vals), 1)
+    support = torch.arange(max_val, device=y_vals.device).unsqueeze(0).repeat(len(y_vals), 1)
     probs_over_support: torch.Tensor = dist.log_prob(support).exp()
     probs_over_support *= support <= y_vals.view(-1, 1)
     cdf = probs_over_support.sum(dim=1)

--- a/probcal/figures/generate_mcmd_in_practice_figure.py
+++ b/probcal/figures/generate_mcmd_in_practice_figure.py
@@ -57,7 +57,7 @@ def produce_figure(
         mcmd_ax: plt.Axes = axs[1, i]
 
         if isinstance(model, GaussianNN):
-            y_hat = model._predict_impl(torch.tensor(X).unsqueeze(1))
+            y_hat = model.predict(torch.tensor(X).unsqueeze(1))
             mu, var = torch.split(y_hat, [1, 1], dim=-1)
             mu = mu.flatten().detach().numpy()
             std = var.sqrt().flatten().detach().numpy()
@@ -65,13 +65,13 @@ def produce_figure(
             nll = np.mean(-np.log(dist.cdf(y + 0.5) - dist.cdf(y - 0.5)))
 
         elif isinstance(model, PoissonNN):
-            y_hat = model._predict_impl(torch.tensor(X).unsqueeze(1))
+            y_hat = model.predict(torch.tensor(X).unsqueeze(1))
             mu = y_hat.detach().numpy().flatten()
             dist = poisson(mu)
             nll = np.mean(-dist.logpmf(y))
 
         elif isinstance(model, NegBinomNN):
-            y_hat = model._predict_impl(torch.tensor(X).unsqueeze(1))
+            y_hat = model.predict(torch.tensor(X).unsqueeze(1))
             mu, alpha = torch.split(y_hat, [1, 1], dim=-1)
             mu = mu.flatten().detach().numpy()
             alpha = alpha.flatten().detach().numpy()
@@ -83,7 +83,7 @@ def produce_figure(
             dist = nbinom(n=n, p=p)
             nll = np.mean(-dist.logpmf(y))
 
-        pred = model._point_prediction(y_hat, training=False).detach().flatten().numpy()
+        pred = model.point_prediction(y_hat, training=False).detach().flatten().numpy()
         mae = np.abs(pred - y).mean()
         lower, upper = dist.ppf(0.025), dist.ppf(0.975)
         plot_posterior_predictive(

--- a/probcal/models/discrete_regression_nn.py
+++ b/probcal/models/discrete_regression_nn.py
@@ -82,56 +82,7 @@ class DiscreteRegressionNN(L.LightningModule):
 
         return optim_dict
 
-    def training_step(self, batch: torch.Tensor) -> torch.Tensor:
-        x, y = batch
-        y_hat = self._forward_impl(x)
-        loss = self.loss_fn(y_hat, y.view(-1, 1).float())
-        self.log("train_loss", loss, prog_bar=True, on_epoch=True)
-
-        with torch.no_grad():
-            point_predictions = self._point_prediction(y_hat, training=True).flatten()
-            self.train_rmse.update(point_predictions, y.flatten().float())
-            self.train_mae.update(point_predictions, y.flatten().float())
-            self.log("train_rmse", self.train_rmse, on_epoch=True)
-            self.log("train_mae", self.train_mae, on_epoch=True)
-
-        return loss
-
-    def validation_step(self, batch: torch.Tensor) -> torch.Tensor:
-        x, y = batch
-        y_hat = self._forward_impl(x)
-        loss = self.loss_fn(y_hat, y.view(-1, 1).float())
-        self.log("val_loss", loss, prog_bar=True, on_epoch=True, sync_dist=True)
-
-        # Since we use _forward_impl, we specify training=True to get the proper transforms.
-        point_predictions = self._point_prediction(y_hat, training=True).flatten()
-        self.val_rmse.update(point_predictions, y.flatten().float())
-        self.val_mae.update(point_predictions, y.flatten().float())
-        self.log("val_rmse", self.val_rmse, on_epoch=True)
-        self.log("val_mae", self.val_mae, on_epoch=True)
-
-        return loss
-
-    def test_step(self, batch: torch.Tensor):
-        x, y = batch
-        y_hat = self._predict_impl(x)
-        point_predictions = self._point_prediction(y_hat, training=False).flatten()
-        self.test_rmse.update(point_predictions, y.flatten().float())
-        self.test_mae.update(point_predictions, y.flatten().float())
-        self._update_addl_test_metrics_batch(x, y_hat, y.view(-1, 1).float())
-
-        self.log("test_rmse", self.test_rmse, on_epoch=True)
-        self.log("test_mae", self.test_mae, on_epoch=True)
-        for name, metric_tracker in self._addl_test_metrics_dict().items():
-            self.log(name, metric_tracker, on_epoch=True)
-
-    def predict_step(self, batch: torch.Tensor) -> torch.Tensor:
-        x, _ = batch
-        y_hat = self._predict_impl(x)
-
-        return y_hat
-
-    def _forward_impl(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
         """Make a forward pass through the network.
 
         Args:
@@ -140,12 +91,12 @@ class DiscreteRegressionNN(L.LightningModule):
         Returns:
             torch.Tensor: Batched output tensor, with shape (N, D_out)
         """
-        raise NotImplementedError("Should be implemented by subclass.")
+        return self._forward_impl(x)
 
-    def _predict_impl(self, x: torch.Tensor) -> torch.Tensor:
+    def predict(self, x: torch.Tensor) -> torch.Tensor:
         """Make a prediction with the network.
 
-        This method will often differ from `_forward_impl` in cases where
+        This method will often differ from `forward` in cases where
         the output used for training is in log (or some other modified)
         space for numerical convenience.
 
@@ -155,9 +106,24 @@ class DiscreteRegressionNN(L.LightningModule):
         Returns:
             torch.Tensor: Batched output tensor, with shape (N, D_out)
         """
-        raise NotImplementedError("Should be implemented by subclass.")
+        return self._predict_impl(x)
 
-    def _point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+    def sample(
+        self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample from this network's posterior predictive distributions for a batch of data (as specified by y_hat).
+
+        Args:
+            y_hat (torch.Tensor): Output tensor from a regression network, with shape (N, ...).
+            training (bool, optional): Boolean indicator specifying if `y_hat` is a training output or not. This particularly matters when outputs are in log space during training, for example. Defaults to False.
+            num_samples (int, optional): Number of samples to take from each posterior predictive. Defaults to 1.
+
+        Returns:
+            torch.Tensor: Batched sample tensor, with shape (N, num_samples).
+        """
+        return self._sample_impl(y_hat, training, num_samples)
+
+    def point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         """Transform the network's output into a single discrete point prediction.
 
         This method will vary depending on the type of regression head (probabilistic vs. deterministic).
@@ -170,6 +136,68 @@ class DiscreteRegressionNN(L.LightningModule):
         Returns:
             torch.Tensor: Point predictions for the true regression target, with shape (N, 1).
         """
+        return self._point_prediction_impl(y_hat, training)
+
+    def training_step(self, batch: torch.Tensor) -> torch.Tensor:
+        x, y = batch
+        y_hat = self(x)
+        loss = self.loss_fn(y_hat, y.view(-1, 1).float())
+        self.log("train_loss", loss, prog_bar=True, on_epoch=True)
+
+        with torch.no_grad():
+            point_predictions = self.point_prediction(y_hat, training=True).flatten()
+            self.train_rmse.update(point_predictions, y.flatten().float())
+            self.train_mae.update(point_predictions, y.flatten().float())
+            self.log("train_rmse", self.train_rmse, on_epoch=True)
+            self.log("train_mae", self.train_mae, on_epoch=True)
+
+        return loss
+
+    def validation_step(self, batch: torch.Tensor) -> torch.Tensor:
+        x, y = batch
+        y_hat = self(x)
+        loss = self.loss_fn(y_hat, y.view(-1, 1).float())
+        self.log("val_loss", loss, prog_bar=True, on_epoch=True, sync_dist=True)
+
+        # Since we used the model's forward method, we specify training=True to get the proper transforms.
+        point_predictions = self.point_prediction(y_hat, training=True).flatten()
+        self.val_rmse.update(point_predictions, y.flatten().float())
+        self.val_mae.update(point_predictions, y.flatten().float())
+        self.log("val_rmse", self.val_rmse, on_epoch=True)
+        self.log("val_mae", self.val_mae, on_epoch=True)
+
+        return loss
+
+    def test_step(self, batch: torch.Tensor):
+        x, y = batch
+        y_hat = self.predict(x)
+        point_predictions = self.point_prediction(y_hat, training=False).flatten()
+        self.test_rmse.update(point_predictions, y.flatten().float())
+        self.test_mae.update(point_predictions, y.flatten().float())
+        self._update_addl_test_metrics_batch(x, y_hat, y.view(-1, 1).float())
+
+        self.log("test_rmse", self.test_rmse, on_epoch=True)
+        self.log("test_mae", self.test_mae, on_epoch=True)
+        for name, metric_tracker in self._addl_test_metrics_dict().items():
+            self.log(name, metric_tracker, on_epoch=True)
+
+    def predict_step(self, batch: torch.Tensor) -> torch.Tensor:
+        x, _ = batch
+        y_hat = self.predict(x)
+        return y_hat
+
+    def _forward_impl(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError("Should be implemented by subclass.")
+
+    def _predict_impl(self, x: torch.Tensor) -> torch.Tensor:
+        raise NotImplementedError("Should be implemented by subclass.")
+
+    def _sample_impl(
+        self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
+    ) -> torch.Tensor:
+        raise NotImplementedError("Should be implemented by subclass.")
+
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         raise NotImplementedError("Should be implemented by subclass.")
 
     def _addl_test_metrics_dict(self) -> dict[str, Metric]:

--- a/probcal/models/discrete_regression_nn.py
+++ b/probcal/models/discrete_regression_nn.py
@@ -11,6 +11,7 @@ from torchmetrics import Metric
 from probcal.enums import LRSchedulerType
 from probcal.enums import OptimizerType
 from probcal.models.backbones import Backbone
+from probcal.random_variables.discrete_random_variable import DiscreteRandomVariable
 
 
 class DiscreteRegressionNN(L.LightningModule):
@@ -123,6 +124,20 @@ class DiscreteRegressionNN(L.LightningModule):
         """
         return self._sample_impl(y_hat, training, num_samples)
 
+    def posterior_predictive(
+        self, y_hat: torch.Tensor, training: bool = False
+    ) -> torch.distributions.Distribution | DiscreteRandomVariable:
+        """Transform the network's outputs into the implied posterior predictive distribution.
+
+        Args:
+            y_hat (torch.Tensor): Output tensor from a regression network, with shape (N, ...).
+            training (bool, optional): Boolean indicator specifying if `y_hat` is a training output or not. This particularly matters when outputs are in log space during training, for example. Defaults to False.
+
+        Returns:
+            torch.distributions.Distribution | DiscreteRandomVariable: The posterior predictive distribution.
+        """
+        return self._posterior_predictive_impl(y_hat, training)
+
     def point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         """Transform the network's output into a single discrete point prediction.
 
@@ -195,6 +210,11 @@ class DiscreteRegressionNN(L.LightningModule):
     def _sample_impl(
         self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
     ) -> torch.Tensor:
+        raise NotImplementedError("Should be implemented by subclass.")
+
+    def _posterior_predictive_impl(
+        self, y_hat: torch.Tensor, training: bool = False
+    ) -> torch.distributions.Distribution | DiscreteRandomVariable:
         raise NotImplementedError("Should be implemented by subclass.")
 
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:

--- a/probcal/models/double_poisson_nn.py
+++ b/probcal/models/double_poisson_nn.py
@@ -128,11 +128,21 @@ class DoublePoissonNN(DiscreteRegressionNN):
         Returns:
             torch.Tensor: Batched sample tensor, with shape (N, num_samples).
         """
-        dist = self._convert_output_to_dist(y_hat, log_output=training)
+        dist = self.posterior_predictive(y_hat, training)
         return dist.rvs((num_samples, dist.dimension)).T
 
+    def _posterior_predictive_impl(
+        self, y_hat: torch.Tensor, training: bool = False
+    ) -> DoublePoisson:
+        output = y_hat.exp() if training else y_hat
+        mu, phi = torch.split(output, [1, 1], dim=-1)
+        mu = mu.flatten()
+        phi = phi.flatten()
+        dist = DoublePoisson(mu, phi)
+        return dist
+
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
-        dist = self._convert_output_to_dist(y_hat, log_output=training)
+        dist = self.posterior_predictive(y_hat, training)
         mode = torch.argmax(dist.pmf_vals, axis=0)
         return mode
 
@@ -145,7 +155,7 @@ class DoublePoissonNN(DiscreteRegressionNN):
     def _update_addl_test_metrics_batch(
         self, x: torch.Tensor, y_hat: torch.Tensor, y: torch.Tensor
     ):
-        dist = self._convert_output_to_dist(y_hat, log_output=False)
+        dist = self.posterior_predictive(y_hat, training=False)
         mu, phi = dist.mu, dist.phi
         precision = phi / mu
         targets = y.flatten()
@@ -153,23 +163,6 @@ class DoublePoissonNN(DiscreteRegressionNN):
 
         self.nll.update(target_probs)
         self.mp.update(precision)
-
-    def _convert_output_to_dist(self, y_hat: torch.Tensor, log_output: bool) -> DoublePoisson:
-        """Convert a network output to the implied Double Poisson distribution.
-
-        Args:
-            y_hat (torch.Tensor): Output from a `DoublePoissonNN` (mu, phi for the predicted distribution over y).
-            log_output (bool): Whether/not output is in log space (such as during training).
-
-        Returns:
-            DoublePoisson: The implied Double Poisson distribution over y.
-        """
-        output = y_hat.exp() if log_output else y_hat
-        mu, phi = torch.split(output, [1, 1], dim=-1)
-        mu = mu.flatten()
-        phi = phi.flatten()
-        dist = DoublePoisson(mu, phi)
-        return dist
 
     def on_train_epoch_end(self):
         if self.beta_scheduler is not None:

--- a/probcal/models/double_poisson_nn.py
+++ b/probcal/models/double_poisson_nn.py
@@ -115,7 +115,23 @@ class DoublePoissonNN(DiscreteRegressionNN):
 
         return torch.exp(y_hat)
 
-    def _point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+    def _sample_impl(
+        self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample from this network's posterior predictive distributions for a batch of data (as specified by y_hat).
+
+        Args:
+            y_hat (torch.Tensor): Output tensor from a regression network, with shape (N, ...).
+            training (bool, optional): Boolean indicator specifying if `y_hat` is a training output or not. This particularly matters when outputs are in log space during training, for example. Defaults to False.
+            num_samples (int, optional): Number of samples to take from each posterior predictive. Defaults to 1.
+
+        Returns:
+            torch.Tensor: Batched sample tensor, with shape (N, num_samples).
+        """
+        dist = self._convert_output_to_dist(y_hat, log_output=training)
+        return dist.rvs((num_samples, dist.dimension)).T
+
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         dist = self._convert_output_to_dist(y_hat, log_output=training)
         mode = torch.argmax(dist.pmf_vals, axis=0)
         return mode

--- a/probcal/models/gaussian_nn.py
+++ b/probcal/models/gaussian_nn.py
@@ -102,7 +102,29 @@ class GaussianNN(DiscreteRegressionNN):
 
         return y_hat
 
-    def _point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+    def _sample_impl(
+        self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample from this network's posterior predictive distributions for a batch of data (as specified by y_hat).
+
+        Args:
+            y_hat (torch.Tensor): Output tensor from a regression network, with shape (N, ...).
+            training (bool, optional): Boolean indicator specifying if `y_hat` is a training output or not. This particularly matters when outputs are in log space during training, for example. Defaults to False.
+            num_samples (int, optional): Number of samples to take from each posterior predictive. Defaults to 1.
+
+        Returns:
+            torch.Tensor: Batched sample tensor, with shape (N, num_samples).
+        """
+        if training:
+            mu, logvar = torch.split(y_hat, [1, 1], dim=-1)
+            var = logvar.exp()
+        else:
+            mu, var = torch.split(y_hat, [1, 1], dim=-1)
+
+        dist = torch.distributions.Normal(loc=mu.squeeze(), scale=var.sqrt().squeeze())
+        return dist.sample((num_samples,)).T
+
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         mu, _ = torch.split(y_hat, [1, 1], dim=-1)
         return mu.round()
 

--- a/probcal/models/gaussian_nn.py
+++ b/probcal/models/gaussian_nn.py
@@ -122,7 +122,8 @@ class GaussianNN(DiscreteRegressionNN):
             mu, var = torch.split(y_hat, [1, 1], dim=-1)
 
         dist = torch.distributions.Normal(loc=mu.squeeze(), scale=var.sqrt().squeeze())
-        return dist.sample((num_samples,)).T
+        sample = dist.sample((num_samples,)).view(num_samples, -1).T
+        return sample
 
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         mu, _ = torch.split(y_hat, [1, 1], dim=-1)

--- a/probcal/models/gaussian_nn.py
+++ b/probcal/models/gaussian_nn.py
@@ -115,6 +115,13 @@ class GaussianNN(DiscreteRegressionNN):
         Returns:
             torch.Tensor: Batched sample tensor, with shape (N, num_samples).
         """
+        dist = self.posterior_predictive(y_hat, training)
+        sample = dist.sample((num_samples,)).view(num_samples, -1).T
+        return sample
+
+    def _posterior_predictive_impl(
+        self, y_hat: torch.Tensor, training: bool = False
+    ) -> torch.distributions.Normal:
         if training:
             mu, logvar = torch.split(y_hat, [1, 1], dim=-1)
             var = logvar.exp()
@@ -122,8 +129,7 @@ class GaussianNN(DiscreteRegressionNN):
             mu, var = torch.split(y_hat, [1, 1], dim=-1)
 
         dist = torch.distributions.Normal(loc=mu.squeeze(), scale=var.sqrt().squeeze())
-        sample = dist.sample((num_samples,)).view(num_samples, -1).T
-        return sample
+        return dist
 
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         mu, _ = torch.split(y_hat, [1, 1], dim=-1)

--- a/probcal/models/neg_binom_nn.py
+++ b/probcal/models/neg_binom_nn.py
@@ -94,7 +94,23 @@ class NegBinomNN(DiscreteRegressionNN):
         self.backbone.train()
         return y_hat
 
-    def _point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+    def _sample_impl(
+        self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample from this network's posterior predictive distributions for a batch of data (as specified by y_hat).
+
+        Args:
+            y_hat (torch.Tensor): Output tensor from a regression network, with shape (N, ...).
+            training (bool, optional): Boolean indicator specifying if `y_hat` is a training output or not. This particularly matters when outputs are in log space during training, for example. Defaults to False.
+            num_samples (int, optional): Number of samples to take from each posterior predictive. Defaults to 1.
+
+        Returns:
+            torch.Tensor: Batched sample tensor, with shape (N, num_samples).
+        """
+        dist = self._convert_output_to_dist(y_hat)
+        return dist.sample((num_samples,)).T
+
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         dist = self._convert_output_to_dist(y_hat)
         return dist.mode
 

--- a/probcal/models/neg_binom_nn.py
+++ b/probcal/models/neg_binom_nn.py
@@ -107,37 +107,13 @@ class NegBinomNN(DiscreteRegressionNN):
         Returns:
             torch.Tensor: Batched sample tensor, with shape (N, num_samples).
         """
-        dist = self._convert_output_to_dist(y_hat)
+        dist = self.posterior_predictive(y_hat, training)
         sample = dist.sample((num_samples,)).view(num_samples, -1).T
         return sample
 
-    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
-        dist = self._convert_output_to_dist(y_hat)
-        return dist.mode
-
-    def _addl_test_metrics_dict(self) -> dict[str, Metric]:
-        return {
-            "nll": self.nll,
-        }
-
-    def _update_addl_test_metrics_batch(
-        self, x: torch.Tensor, y_hat: torch.Tensor, y: torch.Tensor
-    ):
-        dist = self._convert_output_to_dist(y_hat)
-        targets = y.flatten()
-        target_probs = torch.exp(dist.log_prob(targets))
-
-        self.nll.update(target_probs)
-
-    def _convert_output_to_dist(self, y_hat: torch.Tensor) -> torch.distributions.NegativeBinomial:
-        """Convert a network output to the implied negative binomial distribution.
-
-        Args:
-            y_hat (torch.Tensor): Output from a `NegBinomNN` (nbinom parameters for the predicted distribution over y).
-
-        Returns:
-            torch.distributions.NegativeBinomial: The implied negative binomial distribution over y.
-        """
+    def _posterior_predictive_impl(
+        self, y_hat: torch.Tensor, training: bool = False
+    ) -> torch.distributions.NegativeBinomial:
         mu, alpha = torch.split(y_hat, [1, 1], dim=-1)
         mu = mu.flatten()
         alpha = alpha.flatten()
@@ -152,3 +128,21 @@ class NegBinomNN(DiscreteRegressionNN):
         n = mu**2 / torch.maximum(var - mu, eps)
         dist = torch.distributions.NegativeBinomial(total_count=n, probs=failure_prob)
         return dist
+
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+        dist = self.posterior_predictive(y_hat, training)
+        return dist.mode
+
+    def _addl_test_metrics_dict(self) -> dict[str, Metric]:
+        return {
+            "nll": self.nll,
+        }
+
+    def _update_addl_test_metrics_batch(
+        self, x: torch.Tensor, y_hat: torch.Tensor, y: torch.Tensor
+    ):
+        dist = self.posterior_predictive(y_hat, training=False)
+        targets = y.flatten()
+        target_probs = torch.exp(dist.log_prob(targets))
+
+        self.nll.update(target_probs)

--- a/probcal/models/neg_binom_nn.py
+++ b/probcal/models/neg_binom_nn.py
@@ -108,7 +108,8 @@ class NegBinomNN(DiscreteRegressionNN):
             torch.Tensor: Batched sample tensor, with shape (N, num_samples).
         """
         dist = self._convert_output_to_dist(y_hat)
-        return dist.sample((num_samples,)).T
+        sample = dist.sample((num_samples,)).view(num_samples, -1).T
+        return sample
 
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         dist = self._convert_output_to_dist(y_hat)

--- a/probcal/models/poisson_nn.py
+++ b/probcal/models/poisson_nn.py
@@ -88,7 +88,24 @@ class PoissonNN(DiscreteRegressionNN):
 
         return torch.exp(y_hat)
 
-    def _point_prediction(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
+    def _sample_impl(
+        self, y_hat: torch.Tensor, training: bool = False, num_samples: int = 1
+    ) -> torch.Tensor:
+        """Sample from this network's posterior predictive distributions for a batch of data (as specified by y_hat).
+
+        Args:
+            y_hat (torch.Tensor): Output tensor from a regression network, with shape (N, ...).
+            training (bool, optional): Boolean indicator specifying if `y_hat` is a training output or not. This particularly matters when outputs are in log space during training, for example. Defaults to False.
+            num_samples (int, optional): Number of samples to take from each posterior predictive. Defaults to 1.
+
+        Returns:
+            torch.Tensor: Batched sample tensor, with shape (N, num_samples).
+        """
+        lmbda = y_hat.exp() if training else y_hat
+        dist = torch.distributions.Poisson(lmbda.squeeze())
+        return dist.sample((num_samples,)).T
+
+    def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         lmbda = y_hat.exp() if training else y_hat
         return lmbda.floor()
 

--- a/probcal/models/poisson_nn.py
+++ b/probcal/models/poisson_nn.py
@@ -103,7 +103,8 @@ class PoissonNN(DiscreteRegressionNN):
         """
         lmbda = y_hat.exp() if training else y_hat
         dist = torch.distributions.Poisson(lmbda.squeeze())
-        return dist.sample((num_samples,)).T
+        sample = dist.sample((num_samples,)).view(num_samples, -1).T
+        return sample
 
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         lmbda = y_hat.exp() if training else y_hat

--- a/probcal/models/poisson_nn.py
+++ b/probcal/models/poisson_nn.py
@@ -101,10 +101,16 @@ class PoissonNN(DiscreteRegressionNN):
         Returns:
             torch.Tensor: Batched sample tensor, with shape (N, num_samples).
         """
-        lmbda = y_hat.exp() if training else y_hat
-        dist = torch.distributions.Poisson(lmbda.squeeze())
+        dist = self.posterior_predictive(y_hat, training)
         sample = dist.sample((num_samples,)).view(num_samples, -1).T
         return sample
+
+    def _posterior_predictive_impl(
+        self, y_hat: torch.Tensor, training: bool = False
+    ) -> torch.distributions.Poisson:
+        lmbda = y_hat.exp() if training else y_hat
+        dist = torch.distributions.Poisson(lmbda.squeeze())
+        return dist
 
     def _point_prediction_impl(self, y_hat: torch.Tensor, training: bool) -> torch.Tensor:
         lmbda = y_hat.exp() if training else y_hat

--- a/requirements.in
+++ b/requirements.in
@@ -5,6 +5,7 @@ scikit-learn==1.5.0
 tqdm==4.66.4
 lightning==2.4.0
 imgdl==2.0.1
+open_clip_torch==2.26.1
 pip-tools==7.4.1
 pre-commit==3.8.0
 pycocotools==2.0.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,8 +50,12 @@ fsspec[http]==2024.9.0
     #   lightning
     #   pytorch-lightning
     #   torch
+ftfy==6.2.3
+    # via open-clip-torch
 huggingface-hub==0.25.0
     # via
+    #   open-clip-torch
+    #   timm
     #   tokenizers
     #   transformers
 identify==2.6.1
@@ -102,6 +106,8 @@ numpy==1.26.4
     #   torchmetrics
     #   torchvision
     #   transformers
+open-clip-torch==2.26.1
+    # via -r requirements.in
 packaging==24.1
     # via
     #   build
@@ -148,16 +154,21 @@ pyyaml==6.0.1
     #   lightning
     #   pre-commit
     #   pytorch-lightning
+    #   timm
     #   transformers
 regex==2024.9.11
-    # via transformers
+    # via
+    #   open-clip-torch
+    #   transformers
 requests==2.32.3
     # via
     #   huggingface-hub
     #   imgdl
     #   transformers
 safetensors==0.4.5
-    # via transformers
+    # via
+    #   timm
+    #   transformers
 scikit-learn==1.5.0
     # via -r requirements.in
 scipy==1.13.1
@@ -170,6 +181,8 @@ sympy==1.13.2
     # via torch
 threadpoolctl==3.5.0
     # via scikit-learn
+timm==1.0.9
+    # via open-clip-torch
 tokenizers==0.19.1
     # via transformers
 tomli==2.0.1
@@ -180,7 +193,9 @@ torch==2.4.0
     # via
     #   -r requirements.in
     #   lightning
+    #   open-clip-torch
     #   pytorch-lightning
+    #   timm
     #   torchmetrics
     #   torchvision
 torchmetrics==1.4.0
@@ -189,13 +204,17 @@ torchmetrics==1.4.0
     #   lightning
     #   pytorch-lightning
 torchvision==0.19.0
-    # via -r requirements.in
+    # via
+    #   -r requirements.in
+    #   open-clip-torch
+    #   timm
 tqdm==4.66.4
     # via
     #   -r requirements.in
     #   huggingface-hub
     #   imgdl
     #   lightning
+    #   open-clip-torch
     #   pytorch-lightning
     #   transformers
 transformers==4.44.2
@@ -211,8 +230,10 @@ typing-extensions==4.12.2
     #   torch
 urllib3==2.2.3
     # via requests
-virtualenv==20.26.4
+virtualenv==20.26.5
     # via pre-commit
+wcwidth==0.2.13
+    # via ftfy
 wget==3.2
     # via -r requirements.in
 wheel==0.44.0


### PR DESCRIPTION
The MCMD computation is quite involved and has a lot of moving pieces. This is my attempt to standardize the process for any DiscreteRegressionNN with an easy-to-use `CalibrationEvaluator`. Just instantiate one and use its __call__ method, and you get calibration results back (including the ECE). Some basic plot generation functionality is there as well.

To ease some of the logic, I also added a `sample` method to `DiscreteRegressionNN` that will automatically sample `n` times from a model's posterior predictive distribution, and a `posterior_predictive` method that will spit out a distribution object from a set of outputs. Should be useful moving forward