### PR TITLE
Adding code to run MCMD computation multiple times in one eval run

### DIFF
--- a/probcal/evaluation/calibration_evaluator.py
+++ b/probcal/evaluation/calibration_evaluator.py
@@ -14,6 +14,7 @@ import open_clip
 import torch
 from matplotlib import pyplot as plt
 from open_clip import CLIP
+from scipy.interpolate import griddata
 from sklearn.manifold import TSNE
 from torch.utils.data import DataLoader
 from torchvision.transforms import Compose
@@ -29,33 +30,57 @@ from probcal.models.discrete_regression_nn import DiscreteRegressionNN
 
 
 @dataclass
+class MCMDResult:
+    mcmd_vals: np.ndarray
+    mean_mcmd: float
+
+
+@dataclass
 class CalibrationResults:
     input_grid_2d: np.ndarray
     regression_targets: np.ndarray
-    mcmd_vals: np.ndarray
-    mean_mcmd: float
+    mcmd_results: list[MCMDResult]
     ece: float
 
     def save(self, filepath: str | Path):
         if not str(filepath).endswith(".npz"):
             raise ValueError("Filepath must have a .npz extension.")
-        np.savez(
-            filepath,
-            input_grid_2d=self.input_grid_2d,
-            regression_targets=self.regression_targets,
-            mcmd_vals=self.mcmd_vals,
-            mean_mcmd=self.mean_mcmd,
-            ece=self.ece,
+        save_dict = {
+            "input_grid_2d": self.input_grid_2d,
+            "regression_targets": self.regression_targets,
+            "ece": self.ece,
+        }
+        save_dict.update(
+            {
+                f"mcmd_vals_{i}": self.mcmd_results[i].mcmd_vals
+                for i in range(len(self.mcmd_results))
+            }
         )
+        save_dict.update(
+            {
+                f"mean_mcmd_{i}": self.mcmd_results[i].mean_mcmd
+                for i in range(len(self.mcmd_results))
+            }
+        )
+        np.savez(filepath, **save_dict)
 
     @staticmethod
     def load(filepath: str | Path) -> CalibrationResults:
         data: dict[str, np.ndarray] = np.load(filepath)
+        num_trials = max(
+            int(k.split("mean_mcmd_")[-1]) + 1 for k in data.keys() if k.startswith("mean_mcmd_")
+        )
+        mcmd_results = [
+            MCMDResult(
+                mcmd_vals=data[f"mcmd_vals_{i}"],
+                mean_mcmd=data[f"mean_mcmd_{i}"],
+            )
+            for i in range(len(num_trials))
+        ]
         return CalibrationResults(
             input_grid_2d=data["input_grid_2d"],
             regression_targets=data["regression_targets"],
-            mcmd_vals=data["mcmd_vals"],
-            mean_mcmd=data["mean_mcmd"].item(),
+            mcmd_results=mcmd_results,
             ece=data["ece"].item(),
         )
 
@@ -67,6 +92,7 @@ KernelFunction: TypeAlias = Callable[[torch.Tensor, torch.Tensor], torch.Tensor]
 class CalibrationEvaluatorSettings:
     dataset_type: DatasetType = DatasetType.IMAGE
     device: torch.device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+    mcmd_num_trials: int = 5
     mcmd_input_kernel: Literal["polynomial"] | KernelFunction = "polynomial"
     mcmd_output_kernel: Literal["rbf", "laplacian"] | KernelFunction = "rbf"
     mcmd_lambda: float = 0.1
@@ -95,25 +121,36 @@ class CalibrationEvaluator:
         data_module.setup("test")
         test_dataloader = data_module.test_dataloader()
 
-        print("Computing MCMD...")
-        mcmd_vals, grid, targets = self.compute_mcmd(
-            model, test_dataloader, return_grid=True, return_targets=True
-        )
+        print(f"Computing MCMD {self.settings.mcmd_num_trials} separate times...")
+        mcmd_results = []
+        for i in range(self.settings.mcmd_num_trials):
+            mcmd_vals, grid, targets = self.compute_mcmd(
+                model, test_dataloader, return_grid=True, return_targets=True
+            )
 
-        if self.settings.dataset_type == DatasetType.TABULAR:
-            grid_2d = np.array([])
-        else:
-            print("Running TSNE to project grid to 2d...")
-            grid_2d = TSNE().fit_transform(grid.detach().cpu().numpy())
+            # We only need to save the input grid / regression targets once.
+            if i == 0:
+                if self.settings.dataset_type == DatasetType.TABULAR:
+                    grid_2d = np.array([])
+                else:
+                    print("Running TSNE to project grid to 2d...")
+                    grid_2d = TSNE().fit_transform(grid.detach().cpu().numpy())
+                regression_targets = targets.detach().cpu().numpy()
+
+            mcmd_results.append(
+                MCMDResult(
+                    mcmd_vals=mcmd_vals.detach().cpu().numpy(),
+                    mean_mcmd=mcmd_vals.mean().item(),
+                )
+            )
 
         print("Computing ECE...")
         ece = self.compute_ece(model, test_dataloader)
 
         return CalibrationResults(
             input_grid_2d=grid_2d,
-            regression_targets=targets.detach().cpu().numpy(),
-            mcmd_vals=mcmd_vals.detach().cpu().numpy(),
-            mean_mcmd=mcmd_vals.mean().item(),
+            regression_targets=regression_targets,
+            mcmd_results=mcmd_results,
             ece=ece,
         )
 
@@ -193,7 +230,8 @@ class CalibrationEvaluator:
     def plot_mcmd_results(
         self,
         calibration_results: CalibrationResults,
-        gridsize: int = 15,
+        gridsize: int = 100,
+        trial_index: int = 0,
         show: bool = False,
     ) -> plt.Figure:
         """Given a set of calibration results and an existing axes, plot the MCMD values against their 2d input projections on a hexbin grid.
@@ -201,27 +239,35 @@ class CalibrationEvaluator:
         Args:
             calibration_results (CalibrationResults): Calibration results from a CalibrationEvaluator.
             ax (plt.Axes): The axes to draw the plot on.
-            gridsize (int, optional): Gridsize parameter for the hexbin plot. Defaults to 15.
+            gridsize (int, optional): Determines the granularity of the contour plot (higher numbers are more granular). Defaults to 100.
+            trial_index (int, optional): Which MCMD computation to use for the plot (since multiple trials are possible). Defaults to 0 (the first).
             show (bool, optional): Whether/not to show the resultant figure with plt.show(). Defaults to False.
 
         Returns:
             Figure: Matplotlib figure with the visualized MCMD values.
         """
+        mcmd_vals = calibration_results.mcmd_results[trial_index].mcmd_vals
+        mean_mcmd = calibration_results.mcmd_results[trial_index].mean_mcmd
+        input_grid_2d = calibration_results.input_grid_2d
+
         fig, axs = plt.subplots(1, 2, figsize=(10, 4))
         axs: Sequence[plt.Axes]
-        axs[0].set_title("Data")
-        hb1 = axs[0].hexbin(
-            *calibration_results.input_grid_2d.T,
-            calibration_results.regression_targets,
-            gridsize=gridsize,
-        )
-        fig.colorbar(hb1, ax=axs[0])
+        grid_x, grid_y = np.mgrid[
+            min(input_grid_2d[:, 0]) : max(input_grid_2d[:, 0]) : complex(gridsize),
+            min(input_grid_2d[:, 1]) : max(input_grid_2d[:, 1]) : complex(gridsize),
+        ]
 
-        axs[1].set_title(f"Mean MCMD: {calibration_results.mean_mcmd:.4f}")
-        hb2 = axs[1].hexbin(
-            *calibration_results.input_grid_2d.T, calibration_results.mcmd_vals, gridsize=gridsize
+        axs[0].set_title("Data")
+        grid_data = griddata(
+            input_grid_2d, calibration_results.regression_targets, (grid_x, grid_y), method="cubic"
         )
-        fig.colorbar(hb2, ax=axs[1])
+        mappable_0 = axs[0].contourf(grid_x, grid_y, grid_data, levels=20, cmap="viridis")
+        fig.colorbar(mappable_0, ax=axs[0])
+
+        axs[1].set_title(f"Mean MCMD: {mean_mcmd:.4f}")
+        grid_mcmd = griddata(input_grid_2d, mcmd_vals, (grid_x, grid_y), method="cubic")
+        mappable_1 = axs[1].contourf(grid_x, grid_y, grid_mcmd, levels=20, cmap="viridis")
+        fig.colorbar(mappable_1, ax=axs[1])
 
         fig.tight_layout()
 

--- a/probcal/evaluation/eval_model.py
+++ b/probcal/evaluation/eval_model.py
@@ -1,6 +1,6 @@
 import os
 from argparse import ArgumentParser
-from argparse import Namespace
+from functools import partial
 from pathlib import Path
 from typing import Type
 
@@ -8,8 +8,10 @@ import lightning as L
 import torch
 import yaml
 
+from probcal.enums import DatasetType
 from probcal.evaluation.calibration_evaluator import CalibrationEvaluator
 from probcal.evaluation.calibration_evaluator import CalibrationEvaluatorSettings
+from probcal.evaluation.kernels import rbf_kernel
 from probcal.models.discrete_regression_nn import DiscreteRegressionNN
 from probcal.utils.configs import EvaluationConfig
 from probcal.utils.experiment_utils import get_datamodule
@@ -38,11 +40,20 @@ def main(config_path: Path):
         num_nodes=1,
     )
     metrics: dict = evaluator.test(model=model, datamodule=datamodule)[0]
+    metrics = {k: float(v) for k, v in metrics.items()}
+
+    if config.dataset_type == DatasetType.TABULAR and config.input_dim == 1:
+        x_vals = torch.cat([x for x, _ in datamodule.test_dataloader()], dim=0)
+        gamma = (1 / (2 * x_vals.var())).item()
+        mcmd_input_kernel = partial(rbf_kernel, gamma=gamma)
+    else:
+        mcmd_input_kernel = "polynomial"
+
     calibration_eval_settings = CalibrationEvaluatorSettings(
         dataset_type=config.dataset_type,
         device=torch.device(config.accelerator_type.value),
         mcmd_num_trials=config.mcmd_num_trials,
-        mcmd_input_kernel="polynomial",
+        mcmd_input_kernel=mcmd_input_kernel,
         mcmd_output_kernel=config.mcmd_output_kernel,
         mcmd_lambda=config.mcmd_lambda,
         mcmd_num_samples=config.mcmd_num_samples,
@@ -54,20 +65,16 @@ def main(config_path: Path):
     results = calibration_evaluator(model=model, data_module=datamodule)
 
     metrics.update(
-        mean_mcmd=[result.mean_mcmd for result in results.mcmd_results],
-        regression_ece=results.ece,
+        mean_mcmd=[float(result.mean_mcmd) for result in results.mcmd_results],
+        ece=float(results.ece),
     )
     with open(config.log_dir / "test_metrics.yaml", "w") as f:
-        yaml.dump(metrics, f)
+        yaml.safe_dump(metrics, f)
     results.save(config.log_dir / "calibration_results.npz")
 
 
-def parse_args() -> Namespace:
+if __name__ == "__main__":
     parser = ArgumentParser()
     parser.add_argument("--config", type=str, help="Path to evaluation config.yaml.")
-    return parser.parse_args()
-
-
-if __name__ == "__main__":
-    args = parse_args()
+    args = parser.parse_args()
     main(config_path=Path(args.config))

--- a/probcal/evaluation/eval_model.py
+++ b/probcal/evaluation/eval_model.py
@@ -44,6 +44,7 @@ def main(config_path: Path):
     calibration_eval_settings = CalibrationEvaluatorSettings(
         dataset_type=config.dataset_type,
         device=torch.device(config.accelerator_type.value),
+        mcmd_num_trials=config.mcmd_num_trials,
         mcmd_input_kernel="polynomial",
         mcmd_output_kernel=config.mcmd_output_kernel,
         mcmd_lambda=config.mcmd_lambda,

--- a/probcal/utils/configs.py
+++ b/probcal/utils/configs.py
@@ -24,6 +24,7 @@ class BaseConfig(object):
         dataset_type: DatasetType,
         dataset_path_or_spec: Path | ImageDatasetName,
         source_dict: dict,
+        input_dim: int,
         hidden_dim: int,
         batch_size: int,
         accelerator_type: AcceleratorType,
@@ -34,6 +35,7 @@ class BaseConfig(object):
         self.dataset_type = dataset_type
         self.dataset_path_or_spec = dataset_path_or_spec
         self.source_dict = source_dict
+        self.input_dim = input_dim
         self.hidden_dim = hidden_dim
         self.batch_size = batch_size
         self.accelerator_type = accelerator_type
@@ -131,6 +133,7 @@ class TrainingConfig(BaseConfig):
             dataset_type=dataset_type,
             source_dict=source_dict,
             dataset_path_or_spec=dataset_path_or_spec,
+            input_dim=input_dim,
             hidden_dim=hidden_dim,
             batch_size=batch_size,
             accelerator_type=accelerator_type,
@@ -146,7 +149,6 @@ class TrainingConfig(BaseConfig):
         self.beta_scheduler_type = beta_scheduler_type
         self.beta_scheduler_kwargs = beta_scheduler_kwargs
         self.num_trials = num_trials
-        self.input_dim = input_dim
         self.precision = precision
         self.random_seed = random_seed
 
@@ -236,6 +238,7 @@ class EvaluationConfig(BaseConfig):
         dataset_type: DatasetType,
         source_dict: dict,
         dataset_path_or_spec: Path | ImageDatasetName,
+        input_dim: int,
         hidden_dim: int,
         batch_size: int,
         accelerator_type: AcceleratorType,
@@ -255,6 +258,7 @@ class EvaluationConfig(BaseConfig):
             dataset_type=dataset_type,
             source_dict=source_dict,
             dataset_path_or_spec=dataset_path_or_spec,
+            input_dim=input_dim,
             hidden_dim=hidden_dim,
             batch_size=batch_size,
             accelerator_type=accelerator_type,
@@ -290,6 +294,7 @@ class EvaluationConfig(BaseConfig):
         dataset_path_or_spec = TrainingConfig.get_dataset_path_or_spec(config_dict["dataset"])
 
         # Optional arguments.
+        input_dim = config_dict["dataset"].get("input_dim", 1)
         hidden_dim = config_dict.get("hidden_dim", 64)
         batch_size = config_dict.get("batch_size", 1)
         accelerator_type = AcceleratorType(config_dict.get("accelerator", "cpu"))
@@ -311,6 +316,7 @@ class EvaluationConfig(BaseConfig):
             dataset_type=dataset_type,
             source_dict=config_dict,
             dataset_path_or_spec=dataset_path_or_spec,
+            input_dim=input_dim,
             hidden_dim=hidden_dim,
             batch_size=batch_size,
             accelerator_type=accelerator_type,

--- a/probcal/utils/configs.py
+++ b/probcal/utils/configs.py
@@ -241,6 +241,7 @@ class EvaluationConfig(BaseConfig):
         accelerator_type: AcceleratorType,
         log_dir: Path,
         model_ckpt_path: Path,
+        mcmd_num_trials: int,
         mcmd_output_kernel: Literal["rbf", "laplacian"],
         mcmd_lambda: float,
         mcmd_num_samples: int,
@@ -260,6 +261,7 @@ class EvaluationConfig(BaseConfig):
             log_dir=log_dir,
         )
         self.model_ckpt_path = model_ckpt_path
+        self.mcmd_num_trials = mcmd_num_trials
         self.mcmd_output_kernel = mcmd_output_kernel
         self.mcmd_lambda = mcmd_lambda
         self.mcmd_num_samples = mcmd_num_samples
@@ -291,6 +293,7 @@ class EvaluationConfig(BaseConfig):
         hidden_dim = config_dict.get("hidden_dim", 64)
         batch_size = config_dict.get("batch_size", 1)
         accelerator_type = AcceleratorType(config_dict.get("accelerator", "cpu"))
+        mcmd_num_trials = config_dict.get("mcmd_num_trials", 1)
         mcmd_output_kernel = config_dict.get("mcmd_output_kernel", "rbf")
         if mcmd_output_kernel not in ("rbf", "laplacian"):
             raise ValueError("mcmd_output_kernel must be either 'rbf' or 'laplacian'.")
@@ -313,6 +316,7 @@ class EvaluationConfig(BaseConfig):
             accelerator_type=accelerator_type,
             log_dir=log_dir,
             model_ckpt_path=model_ckpt_path,
+            mcmd_num_trials=mcmd_num_trials,
             mcmd_output_kernel=mcmd_output_kernel,
             mcmd_lambda=mcmd_lambda,
             mcmd_num_samples=mcmd_num_samples,


### PR DESCRIPTION
Since the MCMD is a random computation (due to the sampling aspect), we need to be able to run it multiple times for a single eval run so we can report the mean and stdev of the Mean MCMD across runs. This code should implement that.