### PR TITLE
removing errant import. Class no longer defined

### DIFF
--- a/probcal/data_modules/__init__.py
+++ b/probcal/data_modules/__init__.py
@@ -1,7 +1,6 @@
 from .aaf_datamodule import AAFDataModule
 from .coco_people_datamodule import COCOPeopleDataModule
 from .coco_people_datamodule import OodBlurCocoPeopleDataModule
-from .coco_people_datamodule import OodCocoPeopleDataModule
 from .coco_people_datamodule import OodLabelNoiseCocoPeopleDataModule
 from .coco_people_datamodule import OodMixupCocoPeopleDataModule
 from .eva_datamodule import EVADataModule


### PR DESCRIPTION
Removing the import of the `OodCocoPeopleDataModule` class. This class is no longer defined, and has been split over subclasses, `OodBlurCocoPeopleDataModule`, `OodLabelNoiseCocoPeopleDataModule` and `OodMixupCocoPeopleDataModule`