### PR TITLE
Making __init__ optim args optional for Faithful, Natural and NegBinomial models

### DIFF
--- a/probcal/models/faithful_gaussian_nn.py
+++ b/probcal/models/faithful_gaussian_nn.py
@@ -28,8 +28,8 @@ class FaithfulGaussianNN(DiscreteRegressionNN):
         self,
         backbone_type: Type[Backbone],
         backbone_kwargs: dict,
-        optim_type: OptimizerType,
-        optim_kwargs: dict,
+        optim_type: OptimizerType | None,
+        optim_kwargs: dict | None = None,
         lr_scheduler_type: LRSchedulerType | None = None,
         lr_scheduler_kwargs: dict | None = None,
     ):

--- a/probcal/models/faithful_gaussian_nn.py
+++ b/probcal/models/faithful_gaussian_nn.py
@@ -28,7 +28,7 @@ class FaithfulGaussianNN(DiscreteRegressionNN):
         self,
         backbone_type: Type[Backbone],
         backbone_kwargs: dict,
-        optim_type: OptimizerType | None,
+        optim_type: OptimizerType | None = None,
         optim_kwargs: dict | None = None,
         lr_scheduler_type: LRSchedulerType | None = None,
         lr_scheduler_kwargs: dict | None = None,

--- a/probcal/models/natural_gaussian_nn.py
+++ b/probcal/models/natural_gaussian_nn.py
@@ -29,8 +29,8 @@ class NaturalGaussianNN(DiscreteRegressionNN):
         self,
         backbone_type: Type[Backbone],
         backbone_kwargs: dict,
-        optim_type: OptimizerType,
-        optim_kwargs: dict,
+        optim_type: OptimizerType | None = None,
+        optim_kwargs: dict | None = None,
         lr_scheduler_type: LRSchedulerType | None = None,
         lr_scheduler_kwargs: dict | None = None,
     ):

--- a/probcal/models/neg_binom_nn.py
+++ b/probcal/models/neg_binom_nn.py
@@ -30,8 +30,8 @@ class NegBinomNN(DiscreteRegressionNN):
         self,
         backbone_type: Type[Backbone],
         backbone_kwargs: dict,
-        optim_type: OptimizerType,
-        optim_kwargs: dict,
+        optim_type: OptimizerType | None = None,
+        optim_kwargs: dict | None = None,
         lr_scheduler_type: LRSchedulerType | None = None,
         lr_scheduler_kwargs: dict | None = None,
     ):


### PR DESCRIPTION
`optim_kwargs` and `optim_type` constructor arguments changed to optional to allow for evaluation script to be run with those models. 